### PR TITLE
Upgrade to work with Shrine version 3

### DIFF
--- a/.github_changelog_generator
+++ b/.github_changelog_generator
@@ -1,3 +1,3 @@
 unreleased=true
-future-release=0.1.2
+future-release=0.2.0
 exclude-labels=duplicate,question,invalid,wontfix,release

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,7 +37,7 @@ RSpec/ExampleLength:
 RSpec/MultipleExpectations:
   Description: Checks if examples contain too many `expect` calls.
   Enabled: true
-  Max: 5
+  Max: 10
 
 RSpec/MultipleMemoizedHelpers:
   Description: Checks if example groups contain too many `let` and `subject` calls.
@@ -67,6 +67,7 @@ Style/StringLiterals:
 Metrics/AbcSize:
   # The ABC size is a calculated magnitude, so this number can be a Fixnum or
   # a Float.
+  CountRepeatedAttributes: false
   Max: 30
 
 Metrics/ClassLength:

--- a/README.md
+++ b/README.md
@@ -137,7 +137,10 @@ end
 Shrine.plugin :activerecord
 Shrine.plugin :backgrounding
 Shrine.plugin :cached_attachment_data # for forms
-Shrine.plugin :logging, logger: Rails.logger
+
+Shrine.logger = Rails.logger
+Shrine.plugin :instrumentation
+
 Shrine.plugin :rack_file # for non-Rails apps
 Shrine.plugin :remote_url, max_size: 1.gigabyte
 
@@ -360,7 +363,7 @@ by the following command:
 $ gem build shrine-aws-lambda.gemspec
 ```
 
-Assuming the version was set to `0.1.2`, a `shrine-aws-lambda-0.1.2.gem` binary file will be generated at the root of 
+Assuming the version was set to `0.2.0`, a `shrine-aws-lambda-0.2.0.gem` binary file will be generated at the root of 
 the app (repo).
 
 - The binary file shouldn't be added into the `git` tree, it will be pushed into the RubyGems and to the GitHub releases
@@ -368,7 +371,7 @@ the app (repo).
 #### Pushing a new gem release to RubyGems
 
 ```bash
-$ gem push shrine-aws-lambda-0.1.2.gem # don't forget to specify the correct version number
+$ gem push shrine-aws-lambda-0.2.0.gem # don't forget to specify the correct version number
 ```
 
 #### Crafting the new release on GitHub

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Shrine::Plugins::AwsLambda
-Provides [AWS Lambda] integration for [Shrine] File Attachment toolkit for Ruby applications
+Provides [AWS Lambda] integration for the [Shrine] File Attachment toolkit for Ruby applications
 
-This is a gem, renamed from initial [shrine-lambda](https://github.com/texpert/shrine-lambda) to [shrine-aws-lambda](https://github.com/texpert/shrine-aws-lambda) 
-for clarity
+This is a gem, renamed from the initial [shrine-lambda](https://github.com/texpert/shrine-lambda) to [shrine-aws-lambda](https://github.com/texpert/shrine-aws-lambda) for clarity
 
 ## Description
 
@@ -53,7 +52,7 @@ either in the [Shrine] initializer, or in [default profile][AWS profiles] in the
                  region:            'your AWS bucket region' }
 ```
 
-Also, for Lamda functions to work, various [AWS Lamda permissions] should be managed on the [Amazon Web Services] side.
+Also, for Lambda functions to work, various [AWS Lambda permissions] should be managed on the [Amazon Web Services] side.
 
 Add to the [Shrine]'s initializer file the Shrine-AWS-Lambda plugin registration with the `:callback_url` parameter, 
 and the [AWS Lambda] functions list retrieval call (which will retrieve the functions list on application initialization 
@@ -71,11 +70,11 @@ and will store the list into the `Shrine.opts[:lambda_function_list]` for furthe
 By default, Shrine-AWS-Lambda is using the S3 bucket named `:cache` for retrieving the original file, and the `:store` 
 named S3 bucket for storing the resulting files.
 
-Srine-Lamda uses the [Shrine backgrounding plugin] for asynchronous operation, so this plugin should be also included
- into the Shrine's initializer.
+Shrine-AWS-Lambda uses the [Shrine backgrounding plugin] for asynchronous operation, so this plugin should be also 
+included into the Shrine's initializer.
 
-Here is a full example of a Shrine initializer of a [Rails] application using [Roda] endpoints for presigned_url's 
-(used for direct file uploads to [AWS S3]) and [AWS Lambda] callbacks:
+Here is a full example of a Shrine initializer of a [Rails] application using a [Roda] endpoint for presigned_url 
+(used for direct file uploads to [AWS S3]) and [AWS Lambda] callbacks):
 
 ```ruby
 # config/initializers/shrine.rb:
@@ -94,43 +93,31 @@ if Rails.env.test?
 else
   require 'shrine/storage/s3'
 
-  secrets = Rails.application.secrets
+  aws_credentials = Rails.application.credentials.aws
 
-  s3_options = { access_key_id:     secrets.aws_access_key_id,
-                 secret_access_key: secrets.aws_secret_access_key,
+  s3_options = { access_key_id:     aws_credentials[:access_key_id],
+                 secret_access_key: aws_credentials[:secret_access_key],
                  region:            'us-east-2' }
 
   if Rails.env.production?
-    cache_bucket = store_bucket = secrets.aws_s3_bucket
+    cache_bucket = store_bucket = aws_credentials.aws_s3_bucket
   else
     cache_bucket = 'texpert-test-cache'
     store_bucket = 'texpert-test-store'
   end
 
-  Shrine.storages = {
-    cache: Shrine::Storage::S3.new(prefix: 'cache', **s3_options.merge(bucket: cache_bucket)),
-    store: Shrine::Storage::S3.new(prefix: 'store', **s3_options.merge(bucket: store_bucket))
-  }
+  Shrine.storages = { cache: Shrine::Storage::S3.new(prefix: 'cache', **s3_options.merge!(bucket: cache_bucket)), 
+                      store: Shrine::Storage::S3.new(prefix: 'store', **s3_options.merge!(bucket: store_bucket)) }
 
-  lambda_callback_url = if Rails.env.development?
-                          "http://#{ENV['USER']}.localtunnel.me/rapi/lambda"
-                        else
-                          "https://#{ENV.fetch('APP_HOST')}/rapi/lambda"
-                        end
+  ActiveSupport::Reloader.to_prepare do
+   lambda_callback_url = if Rails.env.development? && NGROK_ENABLED
+                          "#{NGROK_URL}/rapi/lambda"
+                         else
+                          "https://#{ENV['APP_HOST'] || 'localhost'}/rapi/lambda"
+                         end
 
-  shrine.plugin :aws_lambda, s3_options.merge(callback_url: lambda_callback_url)
-  Shrine.lambda_function_list
-
-  Shrine.plugin :presign_endpoint, presign_options: ->(request) do
-    filename     = request.params['filename']
-    extension    = File.extname(filename)
-    content_type = Rack::Mime.mime_type(extension)
-
-    {
-      content_length_range: 0..1.gigabyte,                         # limit filesize to 1 GB
-      content_disposition: "attachment; filename=\"#{filename}\"", # download with original filename
-      content_type:        content_type,                           # set correct content type
-    }
+   Shrine.plugin :aws_lambda, s3_options.merge!(callback_url: lambda_callback_url)
+   Shrine.lambda_function_list
   end
 end
 
@@ -141,28 +128,43 @@ Shrine.plugin :cached_attachment_data # for forms
 Shrine.logger = Rails.logger
 Shrine.plugin :instrumentation
 
+Shrine.plugin :presign_endpoint, presign_options: lambda { |request|
+ filename     = request.params['filename']
+ extension    = File.extname(filename)
+ content_type = Rack::Mime.mime_type(extension)
+
+ { content_length_range: 0..1.gigabyte,                         # limit filesize to 1 GB
+   content_disposition: "attachment; filename=\"#{filename}\"", # download with original filename
+   content_type:        content_type }                          # set correct content type
+}
+
 Shrine.plugin :rack_file # for non-Rails apps
 Shrine.plugin :remote_url, max_size: 1.gigabyte
 
-Shrine::Attacher.promote { |data| PromoteJob.perform_later(data) }
-Shrine::Attacher.delete { |data| DeleteJob.perform_later(data) }
-
+Shrine::Attacher.promote_block { PromoteJob.enqueue(self.class.name, record.class.name, record.id, name, file_data) }
+Shrine::Attacher.destroy_block { DeleteJob.enqueue(self.class.name, data) }
 ```
 
-Take notice that the promote job is a default `Shrine::Attacher.promote { |data| PromoteJob.perform_later(data) }`. 
+Take notice that the promote job is a default, not AWS Lambda job: 
+
+```
+Shrine::Attacher.promote_block { PromoteJob.enqueue(self.class.name, record.class.name, record.id, name, file_data) }
+```
+
 This is made to be able to use other than AWS storages in the test environment (like Shrine's `FileSystem` storage) 
-and, also, other uploaders which are not using [AWS Lambda]. This job better to be overrided to a `LambdaPromoteJob` 
- directly in the uploaders' classes which will use [AWS Lambda]. 
+and, also, other uploaders which are not using [AWS Lambda]. To use an AWS Lambda job, this job must be overridden 
+to a `LambdaPromoteJob` directly in the uploaders' classes which will use [AWS Lambda] - see below in the **Usage** 
+chapter. 
  
-Another thing used in this initializer is the [localtunnel] application for exposing the localhost to the world for 
+Another thing used in this initializer is the [ngrok-wrapper] gem for exposing the localhost to the world for 
 catching the Lambda callback requests.
 
 #### How it works
 
-Shrine-Lamnda works in such a way that an "assembly" should be created in the `LambdaUploader`, which contains all 
+Shrine-AWS-Lambda works in such a way that an "assembly" should be created in the `LambdaUploader`, which contains all 
 the information about how the file should be processed. A random generated string is appended to the assembly, stored 
 into the cached file metadata, and used by the Lambda function to sign the requests to the `:lambda_callback_url`, 
-along with the `:access_key_id` from the temporary credentials Lambda function is running with.
+along with the AWS `:access_key_id` from the AWS credentials Lambda function is running with.
 
 Processing itself happens asynchronously - the invoked Lambda function will issue a PUT HTTP request to the  
 `:lambda_callback_url`, specified in the Shrine's initializer, with the request's payload containing the processing  
@@ -171,9 +173,9 @@ results.
 The request should be intercepted by a endpoint at the `:lambda_callback_url`, and its payload transferred to the 
 `lambda_save` method on successful request authorization. 
 
-The authorization is calculatating the HTTP request signature using the random string stored in the cached file and 
-the Lambda function's `:access_key_id` received in the request authorization header. Then, the calculated signature is
- compared to the received in the same authorization header Lambda signature.
+The authorization is calculating the HTTP request signature using the random string stored in the cached file and 
+the AWS Lambda function's `:access_key_id` received in the request authorization header. Then, the calculated 
+signature is compared to the received in the same authorization header AWS Lambda signature.
 
 #### Usage
 
@@ -185,7 +187,11 @@ Shrine-AWS-Lambda assemblies are built inside the `#lambda_process_versions` met
 # frozen_string_literal: true
 
 class LambdaUploader < Uploader
-  Attacher.promote { |data| LambdaPromoteJob.perform_later(data) } unless Rails.env.test?
+  unless Rails.env.test?
+    Attacher.promote_block do
+      LambdaPromoteJob.enqueue(self.class.name, record.class.name, record.id, name, file_data)
+    end
+  end
 
   plugin :upload_options, store: ->(_io, context) do
     if %i[avatar logo].include?(context[:name])
@@ -222,7 +228,6 @@ class LambdaUploader < Uploader
     assembly
   end
 end
-
 ```
 
 The above example is built to interact with the [lambda-image-resize] function, which is using the [Sharp] Javascript
@@ -243,14 +248,13 @@ The default options used by Shrine-AWS-Lambda plugin are the following:
     target_storage: :store }
 ```
 
-These options could be overrided in the `LambdaUploader` specifying them as the `assembly` keys:
+These options could be overridden in the `LambdaUploader` specifying them as the `assembly` keys:
 
 ```ruby
-  assembly[:callbackURL]    = some_callback_url]
-  assembly[:copy_original   = false               # If this is `false`, only the processed file versions will be stored     
+  assembly[:callbackURL]    = some_callback_url
+  assembly[:copy_original]  = false               # If this is `false`, only the processed file versions will be stored     
   assembly[:storages]       = Shrine.buckets_to_use(%i[cache store other_store])
   assembly[:target_storage] = :other_store
-
 ```
 
 Any S3 buckets could be specified, as long as the buckets are defined in the Shrine's initializer file.
@@ -297,7 +301,6 @@ module RAPI
     end
   end
 end
-
 ```
 
 #### Backgrounding
@@ -305,7 +308,13 @@ end
 Even though submitting a Lambda assembly doesn't require any uploading, it still does a HTTP request, so it is better 
 to put it into a background job. This is configured in the `LambdaUploader` class:
 
-`Attacher.promote { |data| LambdaPromoteJob.perform_later(data) } unless Rails.env.test?`
+```ruby
+unless Rails.env.test?
+  Attacher.promote_block do
+    LambdaPromoteJob.enqueue(self.class.name, record.class.name, record.id, name, file_data)
+  end
+end
+```
 
 Then the job file should be implemented:
 
@@ -314,9 +323,11 @@ Then the job file should be implemented:
 
 # frozen_string_literal: true
 
-class LambdaPromoteJob < ApplicationJob
-  def perform(data)
-    Timeout.timeout(30) { Shrine::Attacher.lambda_process(data) }
+class LambdaPromoteJob < Que::Job
+  def run(...)
+    ActiveRecord::Base.transaction do
+     Shrine::Attacher.lambda_process(...)
+    end
   end
 end
 ```
@@ -406,12 +417,12 @@ article], which pointed me to use the [Sharp] library for image resizing.
 [Amazon Web Services]: https://aws.amazon.com
 [AWS blog article]: https://aws.amazon.com/blogs/compute/resize-images-on-the-fly-with-amazon-s3-aws-lambda-and-amazon-api-gateway/
 [AWS Lambda]: https://aws.amazon.com/lambda
-[AWS Lamda permissions]: https://docs.aws.amazon.com/lambda/latest/dg/intro-permission-model.html
+[AWS Lambda permissions]: https://docs.aws.amazon.com/lambda/latest/dg/intro-permission-model.html
 [AWS profiles]: https://docs.aws.amazon.com/cli/latest/userguide/cli-multiple-profiles.html
 [AWS S3]: https://aws.amazon.com/s3/
 [Janko]: https://github.com/janko-m
 [lambda-image-resize]: https://github.com/texpert/lambda-image-resize.js
-[localtunnel]: https://github.com/localtunnel/localtunnel
+[ngrok-wrapper]: https://github.com/texpert/ngrok-wrapper
 [Rails]: http://rubyonrails.org
 [Roda]: http://roda.jeremyevans.net
 [Sharp]: https://github.com/lovell/sharp

--- a/lib/shrine/plugins/aws_lambda.rb
+++ b/lib/shrine/plugins/aws_lambda.rb
@@ -59,9 +59,12 @@ class Shrine
       module AttacherClassMethods
         # Loads the attacher from the data, and triggers its instance AWS Lambda
         # processing method. Intended to be used in a background job.
-        def lambda_process(data)
-          attacher = load(data)
-          attacher.lambda_process(data)
+        def lambda_process(attacher_class, record_class, record_id, name, file_data)
+          attacher_class = Object.const_get(attacher_class)
+          record         = Object.const_get(record_class).find(record_id) # if using Active Record
+
+          attacher = attacher_class.retrieve(model: record, name: name, file: file_data)
+          attacher.lambda_process
           attacher
         end
 
@@ -85,12 +88,20 @@ class Shrine
         # @return [false] if signature in received headers does't match locally computed AWS signature
         def lambda_authorize(headers, body)
           result = JSON.parse(body)
-          attacher = load(result.delete('context'))
+          context = result['context']
+
+          context_record = context['record']
+          record_class   = context_record[0]
+          record_id      = context_record[1]
+          record         = Object.const_get(record_class).find(record_id)
+          attacher_name  = context['name']
+          attacher       = record.send(:"#{attacher_name}_attacher")
+
           incoming_auth_header = auth_header_hash(headers['Authorization'])
 
           signer = build_signer(
             incoming_auth_header['Credential'].split('/'),
-            JSON.parse(attacher.record.__send__(:"#{attacher.data_attribute}") || '{}').dig('metadata', 'key') || 'key',
+            JSON.parse(attacher.record.__send__(:"#{attacher.attribute}") || '{}').dig('metadata', 'key') || 'key',
             headers['x-amz-security-token']
           )
           signature = signer.sign_request(http_method: 'PUT',
@@ -141,8 +152,8 @@ class Shrine
         # errors. No more response analysis is performed, because Lambda is invoked asynchronously (note the
         # `invocation_type`: 'Event' in the `invoke` call). The results will be sent by Lambda by HTTP requests to
         # the specified `callbackUrl`.
-        def lambda_process(data)
-          cached_file = uploaded_file(data['attachment'])
+        def lambda_process
+          cached_file = uploaded_file(self.file)
           assembly = lambda_default_values
           assembly.merge!(store.lambda_process_versions(cached_file, context))
           function = assembly.delete(:function)
@@ -150,13 +161,17 @@ class Shrine
           raise Error, "Function #{function} not available on Lambda!" unless function_available?(function)
 
           prepare_assembly(assembly, cached_file, context)
-          assembly[:context] = data.except('attachment', 'action', 'phase')
+          assembly[:context] = { 'record' => [self.record.class.name, self.record.id],
+                                 'name' => self.name,
+                                 'shrine_class' => self.class.name }
           response = lambda_client.invoke(function_name:   function,
                                           invocation_type: 'Event',
                                           payload:         assembly.to_json)
           raise Error, "#{response.function_error}: #{response.payload.read}" if response.function_error
 
-          swap(cached_file) || _set(cached_file)
+          # swap(cached_file) || _set(cached_file)
+          set(cached_file)
+          atomic_persist(cached_file)
         end
 
         # Receives the `result` hash after Lambda request was authorized. The result could contain an array of
@@ -164,7 +179,7 @@ class Shrine
         # attached file was just moved to the target storage bucket.
         #
         # Deletes the signing key, if it is present in the original file's metadata, converts the result to a JSON
-        # string, and writes this string into the `data_attribute` of the Shrine attacher's record.
+        # string, and writes this string into the `attribute` of the Shrine attacher's record.
         #
         # Chooses the `save_method` either for the ActiveRecord or for Sequel, and saves the record.
         # @param [Hash] result
@@ -179,7 +194,7 @@ class Shrine
                            result.to_json
                          end
 
-          record.__send__(:"#{data_attribute}=", attr_content)
+          record.__send__(:"#{attribute}=", attr_content)
           save_method = case record
                         when ActiveRecord::Base
                           :save

--- a/lib/shrine/plugins/aws_lambda/version.rb
+++ b/lib/shrine/plugins/aws_lambda/version.rb
@@ -3,7 +3,7 @@
 class Shrine
   module Plugins
     module AwsLambda
-      VERSION = '0.1.2'
+      VERSION = '0.2.0'
     end
   end
 end

--- a/shrine-aws-lambda.gemspec
+++ b/shrine-aws-lambda.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'aws-sdk-lambda', '~> 1.0'
   gem.add_dependency 'aws-sdk-s3', '~> 1.2'
-  gem.add_dependency 'shrine', '~> 2.6'
+  gem.add_dependency 'shrine', '~> 3.4'
 
   gem.add_development_dependency 'activerecord', '>= 4.2.0'
   gem.add_development_dependency 'dotenv'

--- a/spec/shrine/plugins/aws_lambda_spec.rb
+++ b/spec/shrine/plugins/aws_lambda_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 require 'active_record'
 require 'shrine'
 require 'shrine/plugins/activerecord'
-require 'shrine/plugins/logging'
+require 'shrine/plugins/instrumentation'
 require 'shrine/storage/s3'
 require 'shrine/plugins/aws_lambda'
 
@@ -61,7 +61,7 @@ RSpec.describe Shrine::Plugins::AwsLambda do
 
       context 'when Shrine logger is enabled' do
         it 'logs the unsupported options' do
-          shrine.plugin :logging
+          shrine.plugin :instrumentation
 
           expect_logged("The :unknown_key option is not supported by the Lambda plugin\n", shrine) do
             shrine.plugin :aws_lambda, option
@@ -157,7 +157,7 @@ RSpec.describe Shrine::Plugins::AwsLambda do
       before do
         user.save!
 
-        allow(Shrine::Attacher).to receive(:load).and_call_original
+        allow(Shrine::Attacher).to receive(:from_data).and_call_original
       end
 
       context 'when signature in received headers matches locally computed AWS signature' do

--- a/spec/support/uploaders_helpers.rb
+++ b/spec/support/uploaders_helpers.rb
@@ -10,7 +10,7 @@ module UploadersHelpers
     uploader.plugin :backgrounding
     uploader.plugin :aws_lambda, settings
 
-    uploader::Attacher.promote do |data|
+    uploader::Attacher.promote_block do |data|
       uploader::Attacher.lambda_process(data)
     end
 


### PR DESCRIPTION
## Changes

- Remove :parsed_json plugin (JSON is now a default), and change `:loggin` to `:instrumentation` plugin
-  Adjust promote and delete jobs' to Shrine-3 - 
  -- the `:promote` method has been changed to `:promote_block`, 
  -- the `:delete` method - to `:destroy_block`
- Change jobs' calling conventions
- Instance `:lambda_process` method is now called without args - all the necessary info is stored into the attacher by the `:lambda_process` class method

## Notes

- This is still using the deprecated Shrine `:versions` plugin
